### PR TITLE
Migrate to uv and add mini_allreduce to installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,12 @@ outputs/
 
 **/build/
 *.so
+
+# UV virtual environments and cache
+.venv/
+venv/
+.uv/
+.cache/uv/
+
+*.md
+!README.md

--- a/README.md
+++ b/README.md
@@ -39,32 +39,44 @@ Furthermore, we align training engine FSDP (TP=1) with the vLLM rollout engine u
 
 
 ## Setup
-1. Install vllm
-```bash
-conda create -n tbik python=3.12 -y
-conda activate tbik
-pip install vllm==0.11.0
-```
-<!-- 2. Install dependencies
-```bash
-pip install datasets latex2sympy2 word2number immutabledict nltk langdetect
-``` -->
 
-2. Install Torchtitan and Flash Attention(This is optional unless you want to try `simple_rl.py`)
+### 1. Install uv
 ```bash
-# Flash Attention
-pip install flash-attn --no-build-isolation
-# Torchtitan
-git clone https://github.com/xh-ding/torchtitan.git
-cd torchtitan
-pip install -e .
-cd ..
+curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
-3. Download this repository
+### 2. Clone and setup
 ```bash
 git clone https://github.com/nanomaoli/llm_reproducibility
 cd llm_reproducibility
+uv venv --python 3.12
+source .venv/bin/activate
+```
+
+### 3. Install core dependencies
+```bash
+uv pip install -e .
+```
+
+### 4. Install mini_allreduce (custom all-reduce kernels)
+```bash
+uv pip install --no-build-isolation -v ./mini_allreduce
+```
+
+### 5. (Optional) Install Flash Attention and TorchTitan for RL experiments
+```bash
+uv pip install flash-attn --no-build-isolation
+git clone https://github.com/xh-ding/torchtitan.git
+cd torchtitan
+uv pip install -e .
+cd ..
+uv pip install -e ".[rl]"
+```
+
+### 6. Verify installation
+```bash
+python verify_installation.py
+python simple_matmul.py
 ```
 
 ## How to use TBIK?

--- a/evaluation/evals/batch/tokenizer.py
+++ b/evaluation/evals/batch/tokenizer.py
@@ -44,7 +44,10 @@ def get_cached_tokenizer(tokenizer: AnyTokenizer) -> AnyTokenizer:
             chat_template = getattr(tokenizer, "chat_template", None)
 
     tokenizer_all_special_ids = set(tokenizer.all_special_ids)
-    tokenizer_all_special_tokens_extended = tokenizer.all_special_tokens_extended
+    # all_special_tokens_extended may not exist in newer transformers versions
+    tokenizer_all_special_tokens_extended = getattr(
+        tokenizer, "all_special_tokens_extended", tokenizer.all_special_tokens
+    )
     tokenizer_all_special_tokens = set(tokenizer.all_special_tokens)
     tokenizer_len = len(tokenizer)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,59 @@
+[project]
+name = "tbik"
+version = "0.1.0"
+description = "Tree-Based Invariant Kernels (TBIK) for deterministic LLM inference across tensor parallel sizes"
+readme = "README.md"
+requires-python = ">=3.10,<3.13"
+dependencies = [
+    "torch>=2.4.0",
+    "vllm==0.11.0",
+    "transformers==4.57",
+    "huggingface-hub>=0.20.0",
+    "safetensors>=0.4.0",
+    "triton>=3.0.0",
+]
+
+[project.optional-dependencies]
+# For reinforcement learning experiments (simple_rl.py)
+rl = [
+    "flash-attn>=2.5.0",
+    "tensorboard>=2.15.0",
+]
+
+# For evaluation tasks
+eval = [
+    "datasets>=2.14.0",
+    "latex2sympy2>=1.9.0",
+    "word2number>=1.1",
+    "immutabledict>=3.0.0",
+    "nltk>=3.8.0",
+    "langdetect>=1.0.9",
+    "tqdm>=4.65.0",
+    "numpy>=1.24.0",
+    "pandas>=2.0.0",
+]
+
+# All optional dependencies
+all = [
+    "flash-attn>=2.5.0",
+    "tensorboard>=2.15.0",
+    "datasets>=2.14.0",
+    "latex2sympy2>=1.9.0",
+    "word2number>=1.1",
+    "immutabledict>=3.0.0",
+    "nltk>=3.8.0",
+    "langdetect>=1.0.9",
+    "tqdm>=4.65.0",
+    "numpy>=1.24.0",
+    "pandas>=2.0.0",
+]
+
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+packages = ["src"]
+
+[tool.setuptools.package-data]
+src = ["**/*.py"]

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,12 @@
+"""
+TBIK (Tree-Based Invariant Kernels) package for deterministic LLM inference.
+"""
+
+__version__ = "0.1.0"
+
+from . import utils
+from . import patch
+from . import tbik
+from . import bio
+
+__all__ = ["utils", "patch", "tbik", "bio"]

--- a/src/bio/__init__.py
+++ b/src/bio/__init__.py
@@ -1,0 +1,7 @@
+"""
+Batch Invariant Operations (BIO) module.
+"""
+
+from .batch_invariant_ops import *
+
+__all__ = ["batch_invariant_ops"]

--- a/src/patch/__init__.py
+++ b/src/patch/__init__.py
@@ -5,7 +5,7 @@ from .patch_training_inference_align import patch_training_inference_align
 __all__ = ["apply_patches"]
 
 def apply_patches():
-    from utils import batch_invariant_is_enabled, tp_invariant_is_enabled, compatible_mode_is_enabled
+    from src.utils import batch_invariant_is_enabled, tp_invariant_is_enabled, compatible_mode_is_enabled
     if not batch_invariant_is_enabled() and not tp_invariant_is_enabled() and not compatible_mode_is_enabled():
         print("No patches applied to vLLM\n")
         return

--- a/src/tbik/__init__.py
+++ b/src/tbik/__init__.py
@@ -1,0 +1,8 @@
+"""
+Tree-Based Invariant Kernels (TBIK) module.
+"""
+
+from .tree_based_matmul import *
+from .tree_based_all_reduce import *
+
+__all__ = ["tree_based_matmul", "tree_based_all_reduce"]

--- a/verify_installation.py
+++ b/verify_installation.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""
+Verification script for TBIK installation.
+Run this script to verify that all core dependencies are installed correctly.
+"""
+
+import sys
+import importlib.util
+
+def check_package(package_name, import_name=None, optional=False):
+    """Check if a package is installed."""
+    if import_name is None:
+        import_name = package_name
+
+    try:
+        spec = importlib.util.find_spec(import_name)
+        if spec is not None:
+            print(f"✓ {package_name:20s} - installed")
+            return True
+        else:
+            if optional:
+                print(f"⊘ {package_name:20s} - not installed (optional)")
+            else:
+                print(f"✗ {package_name:20s} - NOT FOUND")
+            return False
+    except (ImportError, ModuleNotFoundError, ValueError):
+        if optional:
+            print(f"⊘ {package_name:20s} - not installed (optional)")
+        else:
+            print(f"✗ {package_name:20s} - NOT FOUND")
+        return False
+
+def check_cuda():
+    """Check if CUDA is available."""
+    try:
+        import torch
+        if torch.cuda.is_available():
+            device_count = torch.cuda.device_count()
+            device_name = torch.cuda.get_device_name(0)
+            print(f"✓ CUDA                - available ({device_count} GPU(s), {device_name})")
+            return True
+        else:
+            print("✗ CUDA                - NOT AVAILABLE")
+            return False
+    except Exception as e:
+        print(f"✗ CUDA                - ERROR: {e}")
+        return False
+
+def check_mini_allreduce():
+    """Check if mini_allreduce is installed."""
+    try:
+        from mini_allreduce import CustomTreeAllreduce
+        print("✓ mini_allreduce      - installed")
+        return True
+    except ImportError as e:
+        print(f"✗ mini_allreduce      - NOT INSTALLED")
+        print(f"  Error: {e}")
+        print(f"  Install with: uv pip install --no-build-isolation -v ./mini_allreduce")
+        return False
+
+def check_src_package():
+    """Check if the src package is properly installed."""
+    try:
+        from src.patch import apply_patches
+        from src.utils import batch_invariant_is_enabled
+        from src.tbik.tree_based_matmul import matmul_tp_persistent
+        print("✓ src package         - installed")
+        return True
+    except ImportError as e:
+        print(f"✗ src package         - NOT PROPERLY INSTALLED")
+        print(f"  Error: {e}")
+        print(f"  Install with: uv pip install -e .")
+        return False
+
+def main():
+    print("=" * 60)
+    print("TBIK Installation Verification")
+    print("=" * 60)
+    print()
+
+    print("Core Dependencies:")
+    print("-" * 60)
+    core_ok = True
+    core_ok &= check_package("torch")
+    core_ok &= check_package("vllm")
+    core_ok &= check_package("transformers")
+    core_ok &= check_package("huggingface_hub", "huggingface_hub")
+    core_ok &= check_package("safetensors")
+    core_ok &= check_package("triton")
+    print()
+
+    print("CUDA:")
+    print("-" * 60)
+    cuda_ok = check_cuda()
+    print()
+
+    print("TBIK Packages:")
+    print("-" * 60)
+    tbik_ok = True
+    tbik_ok &= check_src_package()
+    tbik_ok &= check_mini_allreduce()
+    print()
+
+    print("Optional Dependencies (for RL experiments):")
+    print("-" * 60)
+    check_package("flash_attn", "flash_attn", optional=True)
+    check_package("torchtitan", "torchtitan", optional=True)
+    check_package("tensorboard", "torch.utils.tensorboard", optional=True)
+    print()
+
+    print("Optional Dependencies (for evaluation):")
+    print("-" * 60)
+    check_package("datasets", optional=True)
+    check_package("latex2sympy2", optional=True)
+    check_package("word2number", optional=True)
+    check_package("immutabledict", optional=True)
+    check_package("nltk", optional=True)
+    check_package("langdetect", optional=True)
+    check_package("tqdm", optional=True)
+    check_package("numpy", optional=True)
+    check_package("pandas", optional=True)
+    print()
+
+    print("=" * 60)
+    print("Summary:")
+    print("=" * 60)
+
+    if core_ok and cuda_ok and tbik_ok:
+        print("✓ All core components are installed correctly!")
+        print("\nYou can now run:")
+        print("  - python simple_matmul.py")
+        print("  - python simple_inference.py")
+        print("  - python tests/test_custom_tree_allreduce.py (requires multiple GPUs)")
+        return 0
+    else:
+        print("✗ Some core components are missing.")
+        print("\nPlease follow the installation instructions in README.md")
+        return 1
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
- Migrate from conda to uv for package management
- Add mini_allreduce installation steps (was missing)
- Create pyproject.toml with dependencies
- Add verify_installation.py script
- Fix Qwen2Tokenizer compatibility issue
- Add proper package structure (__init__.py files)